### PR TITLE
feat: Log price ticks to database

### DIFF
--- a/cmd/referee/main.go
+++ b/cmd/referee/main.go
@@ -10,7 +10,6 @@ import (
 	"referee/internal/database"
 	"referee/internal/exchange"
 	"syscall"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
@@ -43,6 +42,13 @@ func main() {
 
 	// Create repository
 	repo := &database.PostgresRepository{Pool: pool}
+
+	// Run database migrations
+	if err := repo.Migrate(context.Background()); err != nil {
+		logger.Error("Failed to run database migrations", "error", err)
+		os.Exit(1)
+	}
+	logger.Info("Database migrations completed successfully")
 
 	// Create arbitrage engine
 	engine := arbitrage.NewArbitrageEngine(logger, repo, &cfg)

--- a/internal/arbitrage/engine.go
+++ b/internal/arbitrage/engine.go
@@ -29,6 +29,11 @@ func NewArbitrageEngine(logger *slog.Logger, repo database.Repository, cfg *conf
 
 // ProcessTick processes a new price tick to check for arbitrage opportunities.
 func (e *ArbitrageEngine) ProcessTick(ctx context.Context, tick model.PriceTick) {
+	// Log the incoming price tick
+	if err := e.repo.LogPriceTick(ctx, tick); err != nil {
+		e.logger.Error("Failed to log price tick", "error", err)
+	}
+
 	// Update the latest price for this exchange
 	e.latestPrices[tick.Exchange] = tick
 
@@ -79,7 +84,7 @@ func (e *ArbitrageEngine) checkAndExecuteArbitrage(ctx context.Context, buyExcha
 		// Log the trade
 		trade := model.SimulatedTrade{
 			Timestamp:      time.Now(),
-			TradingPair:    "BTC/EUR",
+			TradingPair:    e.cfg.Arbitrage.TradingPair,
 			BuyExchange:    buyExchange,
 			SellExchange:   sellExchange,
 			BuyPrice:       buyPrice,

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -11,11 +11,23 @@ import (
 // Repository defines the standard interface for database operations.
 type Repository interface {
 	LogTrade(ctx context.Context, trade model.SimulatedTrade) error
+	LogPriceTick(ctx context.Context, tick model.PriceTick) error
+	Migrate(ctx context.Context) error
 }
 
 // PostgresRepository is the PostgreSQL implementation of the Repository.
 type PostgresRepository struct {
 	Pool *pgxpool.Pool
+}
+
+// LogPriceTick inserts a new price tick into the database.
+func (r *PostgresRepository) LogPriceTick(ctx context.Context, tick model.PriceTick) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	query := `INSERT INTO price_ticks (timestamp, exchange, pair, bid, ask) VALUES ($1, $2, $3, $4, $5)`
+	_, err := r.Pool.Exec(ctx, query, time.Now(), tick.Exchange, tick.Pair, tick.Bid, tick.Ask)
+	return err
 }
 
 // LogTrade inserts a new simulated trade into the database.
@@ -43,4 +55,45 @@ func (r *PostgresRepository) LogTrade(ctx context.Context, trade model.Simulated
 	)
 
 	return err
+}
+
+// Migrate creates the necessary database tables if they do not exist.
+func (r *PostgresRepository) Migrate(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Create simulated_trades table
+	tradesTableQuery := `
+		CREATE TABLE IF NOT EXISTS simulated_trades (
+			id SERIAL PRIMARY KEY,
+			timestamp TIMESTAMPTZ NOT NULL,
+			trading_pair VARCHAR(20) NOT NULL,
+			buy_exchange VARCHAR(50) NOT NULL,
+			sell_exchange VARCHAR(50) NOT NULL,
+			buy_price NUMERIC(20, 8) NOT NULL,
+			sell_price NUMERIC(20, 8) NOT NULL,
+			volume_eur NUMERIC(20, 8) NOT NULL,
+			gross_profit_eur NUMERIC(20, 8) NOT NULL,
+			total_fees_eur NUMERIC(20, 8) NOT NULL,
+			net_profit_eur NUMERIC(20, 8) NOT NULL
+		);`
+	if _, err := r.Pool.Exec(ctx, tradesTableQuery); err != nil {
+		return err
+	}
+
+	// Create price_ticks table
+	ticksTableQuery := `
+		CREATE TABLE IF NOT EXISTS price_ticks (
+			id SERIAL PRIMARY KEY,
+			timestamp TIMESTAMPTZ NOT NULL,
+			exchange VARCHAR(50) NOT NULL,
+			pair VARCHAR(20) NOT NULL,
+			bid NUMERIC(20, 8) NOT NULL,
+			ask NUMERIC(20, 8) NOT NULL
+		);`
+	if _, err := r.Pool.Exec(ctx, ticksTableQuery); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This commit introduces the functionality to log every price tick received from the exchanges to the database. This will allow for better monitoring and analysis of the bot's behavior in Metabase.

Key changes:
- Added a  table to the database.
- Implemented a  method in the .
- Updated the  to log every price tick it receives.