### PR TITLE
feat: Refactor arbitrage engine to use a synchronized, periodic check

### DIFF
--- a/cmd/referee/main.go
+++ b/cmd/referee/main.go
@@ -10,7 +10,6 @@ import (
 	"referee/internal/database"
 	"referee/internal/exchange"
 	"syscall"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
@@ -70,14 +69,18 @@ func main() {
 	// Create the fan-in channel for price ticks
 	priceChan := make(chan model.PriceTick, 100)
 
-	// Start the arbitrage engine goroutine
+	// Start the arbitrage engine
 	eg.Go(func() error {
-		logger.Info("Starting arbitrage engine")
+		engine.Start(gCtx)
+		return nil
+	})
+
+	// Start a goroutine to process incoming prices
+	eg.Go(func() error {
 		for {
 			select {
 			case <-gCtx.Done():
-				logger.Info("Arbitrage engine shutting down")
-				return gCtx.Err()
+				return nil
 			case tick := <-priceChan:
 				engine.ProcessTick(gCtx, tick)
 			}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,8 @@ arbitrage:
   simulated_latency_ms: 50
   # The trading pair to monitor for arbitrage opportunities.
   trading_pair: "BTC/EUR"
+  # The interval in milliseconds at which the bot checks for arbitrage opportunities.
+  check_interval_ms: 5000
 
 # PostgreSQL database connection details.
 # IMPORTANT: Use environment variables for sensitive values in production.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type ArbitrageConfig struct {
 	NetworkWithdrawalFeeEUR float64 `mapstructure:"network_withdrawal_fee_eur"`
 	SimulatedLatencyMS      int     `mapstructure:"simulated_latency_ms"`
 	TradingPair             string  `mapstructure:"trading_pair"`
+	CheckIntervalMS         int     `mapstructure:"check_interval_ms"`
 }
 
 // DatabaseConfig defines the database connection settings.


### PR DESCRIPTION
This commit refactors the arbitrage engine to use a more robust, synchronized, and periodic checking mechanism. The previous algorithm was prone to acting on stale data, as it would react to individual price ticks without a complete, up-to-date view of the market.

The new algorithm works as follows:
- A dedicated goroutine runs at a configurable interval (defaulting to 5 seconds).
- At each interval, it checks for arbitrage opportunities using the most recent prices from all exchanges.
- This ensures that the bot is working with a more current and holistic view of the market, increasing the chances of identifying real arbitrage opportunities.

This change also includes:
- A new  configuration option.
- A new  method to start the arbitrage checking loop.
- A mutex to protect the  map from race conditions.